### PR TITLE
Add the ability to reference other DLLs

### DIFF
--- a/Kaxaml.sln
+++ b/Kaxaml.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kaxaml", "Kaxaml\Kaxaml.csproj", "{FF5B3F61-822A-4154-9215-43D4A835EDF4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KaxamlPlugins", "KaxamlPlugins\KaxamlPlugins.csproj", "{F6B1B201-8293-4729-842C-0BB54F89FFA7}"

--- a/Kaxaml/DocumentViews/WpfDocumentView.xaml.cs
+++ b/Kaxaml/DocumentViews/WpfDocumentView.xaml.cs
@@ -400,6 +400,8 @@ namespace Kaxaml.DocumentViews
 
                                 ContentArea.JournalOwnership = System.Windows.Navigation.JournalOwnership.UsesParentJournal;
                                 content = XamlReader.Load(ms, pc);
+                                //content = XamlReader.Load(ms);
+                                MainWindow.AddResources(content);
                             }
                         }
 

--- a/Kaxaml/MainWindow.xaml.cs
+++ b/Kaxaml/MainWindow.xaml.cs
@@ -204,21 +204,29 @@ namespace Kaxaml
 
                 if (arg == "-i")
                 {
+                    // Handle the include command. This allows us to add dlls and static resources to the editor
                     string nextArg = (i < args.Length - 1) ? args[i + 1] : null;
-                    if (nextArg != null && System.IO.File.Exists(nextArg))
+                    if (nextArg != null)
                     {
                         try
                         {
-                            if (nextArg.EndsWith(".xaml", StringComparison.InvariantCultureIgnoreCase))
+                            if (nextArg.StartsWith("pack://"))
                             {
                                 XamlResources.Add(nextArg);
                             }
-                            else if (nextArg.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase))
+                            else if (System.IO.File.Exists(nextArg))
                             {
-                                Assembly.LoadFile(nextArg);
+                                if (nextArg.EndsWith(".xaml", StringComparison.InvariantCultureIgnoreCase))
+                                {
+                                    XamlResources.Add(nextArg);
+                                }
+                                else if (nextArg.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase))
+                                {
+                                    Assembly.LoadFile(nextArg);
 
-                                string dir = System.IO.Path.GetDirectoryName(nextArg);
-                                AssemblySearchDirs.Add(dir);
+                                    string dir = System.IO.Path.GetDirectoryName(nextArg);
+                                    AssemblySearchDirs.Add(dir);
+                                }
                             }
                         }
                         catch (Exception ex)
@@ -283,7 +291,15 @@ namespace Kaxaml
         {
             foreach (string filePath in XamlResources)
             {
-                ResourceDictionary resDict = XamlReader.Load(System.IO.File.Open(filePath, System.IO.FileMode.Open)) as ResourceDictionary;
+                ResourceDictionary resDict = null;
+                if (filePath.StartsWith("pack://"))
+                {
+                    resDict = new ResourceDictionary() { Source = new Uri(filePath) };
+                }
+                else
+                {
+                    resDict = XamlReader.Load(System.IO.File.Open(filePath, System.IO.FileMode.Open)) as ResourceDictionary;
+                }
                 if (resDict != null)
                 {
                     if (element is FrameworkElement)

--- a/KaxamlPlugins/KaxamlInfo.cs
+++ b/KaxamlPlugins/KaxamlInfo.cs
@@ -40,7 +40,9 @@ namespace KaxamlPlugins
 
         static void _Editor_TextSelectionChanged(object sender, RoutedEventArgs e)
         {
-            EditSelectionChanged(_Editor.SelectedText);
+            var handler = EditSelectionChanged;
+            if (handler != null)
+                handler(_Editor.SelectedText);
         }
 
         private static Window _MainWindow;


### PR DESCRIPTION
I have added the ability to reference other DLLs and .xaml ResourceDictionaries. This can be useful if you have your custom WPF controls or Styles and want to reference them in the .xaml documents.

for example this allows me to work with a .xaml like below by starting kaxaml with the following command line parameters: `-i C:\pathto\MyControls.WPF.dll -i C:\pathto\ResDict.xaml`. Previously this would have failed. Adding my DLL to the kaxaml installation folder would have solved the problem of recognizing the namespace, but it would still have failed when trying to use the StaticResources:

```
<StackPanel xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
           xmlns:myControls="clr-namespace:MyControls.WPF.Controls.myControls;assembly=MyControls.WPF">
  <myControls:MyCustomControl ShowIdentifier="false" DatabaseId="0" ViewTemplate="{StaticResource HexTextBlock}" />
  <myControls:MyCustomControl ShowIdentifier="false" DatabaseId="2" ViewTemplate="{StaticResource VolumeMeter160to60}" />
  <myControls:MyCustomControl ShowIdentifier="false" DatabaseId="1" ViewTemplate="{StaticResource VolumeMeter160to60PeakRider}" />
  <myControls:MyCustomControl ShowIdentifier="false" DatabaseId="0" ViewTemplate="{StaticResource VolumeMeter160to60}" />

  <StackPanel Orientation="Horizontal">
    <TextBlock Text="Some horizontal values:" />
    <myControls:MyCustomControl ShowIdentifier="false" DatabaseId="2" ViewTemplate="{StaticResource SimpleFloatTextBlock}" />
    <myControls:MyCustomControl ShowIdentifier="false" DatabaseId="1" ViewTemplate="{StaticResource FloatTextBlock}" Index="1" />
    <myControls:MyCustomControl ShowIdentifier="false" DatabaseId="0" ViewTemplate="{StaticResource SimpleFloatTextBlock}" Index="2" />
  </StackPanel>
</StackPanel>
```
